### PR TITLE
3.5 now tested (and only 2.7). Old issue: 3.3 in not actually tested.., README should then not say [ci skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
     - 2.7
-    - 3.4
+    - 3.5
 compiler:
   - clang
 notifications:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ python -m unittest discover
 
 **Note** You need to explicitly add julia to your PATH, an alias will not work.
 
-`pyjulia` is tested against Python versions 2.7 and 3.4.  Older versions of Python are not supported.
+`pyjulia` is tested against Python versions 2.7 and 3.5 (older should work).  Older versions of Python are not supported.
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ python -m unittest discover
 
 **Note** You need to explicitly add julia to your PATH, an alias will not work.
 
-`pyjulia` is tested against Python versions 2.7, 3.3 and 3.4.  Older versions of Python are not supported.
+`pyjulia` is tested against Python versions 2.7 and 3.4.  Older versions of Python are not supported.
 
 Installation
 ------------


### PR DESCRIPTION
..if I'm reading .travis.yml right. I do not actually care. Not pushing for 3.5 to be tested, but it is current (actually 3.5.1 and 2.7.11 just out), and maybe want to add that there and here (and drop 3.4? While it's also current I think)?

There seems to be no activity in the code (while I see discussions in issues). My guess is that doesn't reflect true nature, as fixes in PyCall.jl help here?